### PR TITLE
Replace train_population with a Trainer struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,42 +19,35 @@ cargo add neuralneat
 The usual flow of evolving a neural network with Neural NEAT is to create a `Pool`, test each `Genome` in the `Pool`, and then spawn a new generation before repeating this process as many times as you want or need. For example:
 
 ```
-let input_nodes = 5;
-let output_nodes = 1;
-// Create an initial pool of Genomes
-let gene_pool = Pool::with_defaults(input_nodes, output_nodes);
+use neuralneat::{Genome, Pool, Trainer};
+use neuralneat::evaluation::TrainingData;
 
-// Load the data that will be used to train and evolve the Genomes
-let training_data: Vec<TrainingData> = load_training_data();
-
-// This function is used to evaluate the outputs of the Genomes after being
-// fed each piece of training data.
-fn evaluate_fitness(outputs: &Vec<f32>, expected: &Vec<f32>) -> f32 {
-    assert_eq!(outputs.len(), expected.len());
-
-    let mut fitness = 0.0;
-    for i in outputs.len() {
-        if outputs[i] == expected[i] {
-            fitness += 1.0;
-        }
-    }
-
-    return fitness;
+// To do something useful, you need to decide what your training data is!
+fn load_training_data() -> Vec<TrainingData> {
+    return vec![];
 }
 
-gene_pool.train_population(
-    // Train for 100 generations
-    100,
-    // The training data
-    &training_data,
-    // The function to be called to evaluate how well a Genome is performing
-    evaluate_fitness,
-    None,
-    None,
-);
-
-// The winner!
-let best_genome = gene_pool.get_best_genome();
+fn main() {
+    let input_nodes = 5;
+    let output_nodes = 1;
+    // Create an initial pool of Genomes
+    let mut gene_pool = Pool::with_defaults(input_nodes, output_nodes);
+    
+    // Load the data that will be used to train and evolve the Genomes
+    let training_data: Vec<TrainingData> = load_training_data();
+    
+    // A Trainer can manage the process of training a population of Genomes
+    // over successive generations.
+    let mut trainer = Trainer::new(training_data);
+    
+    trainer.train(
+        &mut gene_pool,
+        // Train for 100 generations
+        100,
+    );
+    // The winner!
+    let best_genome = gene_pool.get_best_genome();
+}
 ```
 
 # Examples

--- a/examples/adding_managed.rs
+++ b/examples/adding_managed.rs
@@ -1,5 +1,5 @@
 /* This example will train a neural network that can sum its inputs */
-use neuralneat::{Genome, Pool};
+use neuralneat::{Genome, Pool, Trainer};
 use serde_json;
 use std::env;
 use std::fs::File;
@@ -29,18 +29,17 @@ fn main() {
 
         let training_data = load_training_data(TRAINING_DATA_STRING, 4, 1);
 
+        let mut trainer = Trainer::new(training_data);
+        // This function will be called once per Genome per piece of
+        // TrainingData in each generation, passing the values of the
+        // output nodes of the Genome as well as the expected result
+        // from the TrainingData.
+        trainer.evaluate_fn = adding_fitness_func;
+        trainer.hidden_activation = linear_activation;
+        trainer.output_activation = linear_activation;
+
         // Train over the course of 100 generations
-        gene_pool.train_population(
-            100,
-            &training_data,
-            // This function will be called once per Genome per piece of
-            // TrainingData in each generation, passing the values of the
-            // output nodes of the Genome as well as the expected result
-            // from the TrainingData.
-            adding_fitness_func,
-            Some(linear_activation),
-            Some(linear_activation),
-        );
+        trainer.train(&mut gene_pool, 100);
 
         let best_genome = gene_pool.get_best_genome();
 

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -15,6 +15,19 @@ pub fn sigmoid(x: f32) -> f32 {
     return 1.0 / (1.0 + z.exp());
 }
 
+pub fn basic_eval(outputs: &Vec<f32>, expected: &Vec<f32>) -> f32 {
+    assert_eq!(outputs.len(), expected.len());
+
+    let mut fitness = 0.0;
+    for i in 0..outputs.len() {
+        if outputs[i] == expected[i] {
+            fitness += 1.0;
+        }
+    }
+
+    return fitness;
+}
+
 pub struct TrainingData {
     pub inputs: Vec<f32>,
     pub expected: Vec<f32>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,41 @@
 //!
 //! Much of this implementation was also guided by the [NEAT 1.2.1 source code](
 //! https://nn.cs.utexas.edu/?neat).
+//!
+//! # Basic usage:
+//!
+//! ```
+//! use neuralneat::{Genome, Pool, Trainer};
+//! use neuralneat::evaluation::TrainingData;
+//!
+//! // To do something useful, you need to decide what your training data is!
+//! fn load_training_data() -> Vec<TrainingData> {
+//!     return vec![];
+//! }
+//!
+//! fn main() {
+//!     let input_nodes = 5;
+//!     let output_nodes = 1;
+//!     // Create an initial pool of Genomes
+//!     let mut gene_pool = Pool::with_defaults(input_nodes, output_nodes);
+//!     
+//!     // Load the data that will be used to train and evolve the Genomes
+//!     let training_data: Vec<TrainingData> = load_training_data();
+//!     
+//!     // A Trainer can manage the process of training a population of Genomes
+//!     // over successive generations.
+//!     let mut trainer = Trainer::new(training_data);
+//!     
+//!     trainer.train(
+//!         &mut gene_pool,
+//!         // Train for 100 generations
+//!         100,
+//!     );
+//!
+//!     // The winner!
+//!     let best_genome = gene_pool.get_best_genome();
+//! }
+//! ```
 
 /// The [defaults] module contains the default values of all of the constants
 /// used by the [Pool] to create, mutate, and mate [Genomes](Genome).
@@ -18,7 +53,9 @@ pub mod evaluation;
 mod genome;
 mod pool;
 mod species;
+mod training;
 
 pub use genome::{Genome, GenomeStats};
 pub use pool::{Pool, PoolStats};
 pub use species::{Species, SpeciesStats};
+pub use training::Trainer;

--- a/src/training.rs
+++ b/src/training.rs
@@ -1,0 +1,81 @@
+use log::info;
+
+use crate::evaluation::{basic_eval, sigmoid, ActivationFn, EvaluationFn, TrainingData};
+use crate::Pool;
+
+/// A Trainer will manage the training cycle for a population of [Genomes](crate::Genome).
+pub struct Trainer {
+    /// The data used to train the [Genomes](crate::Genome). Each [crate::Genome] will be given the
+    /// [inputs](TrainingData::inputs) from each [TrainingData] as input their networks.
+    training_data: Vec<TrainingData>,
+    /// A function that can score a [Genome](crate::Genome) after each piece of [TrainingData] is
+    /// fed to it. This function will be passed a Vec of the [Genome](crate::Genome)'s outputs and
+    /// the [expected](TrainingData::expected) value or values from the [TrainingData]. This
+    /// function is expected to assess the [Genome](crate::Genome)'s performance by comparing the
+    /// two, and returning an f32 representing its "score". The score from each call to
+    /// `evaluate_fn` will be summed together to form the final fitness value of each
+    /// [Genome](crate::Genome).
+    pub evaluate_fn: EvaluationFn,
+    /// The [ActivationFn] to use for the hidden layers of each [Genome](crate::Genome)'s network.
+    pub hidden_activation: ActivationFn,
+    /// The [ActivationFn] to use for the output layer of each [Genome](crate::Genome)'s network.
+    pub output_activation: ActivationFn,
+}
+
+impl Trainer {
+    /// Create a new Trainer that will use the given `training_data` to train a [Pool]'s
+    /// [Genomes](crate::Genome) when [train](Trainer::train) is called. Other parameters
+    /// (eg: [evaluate_fn](Trainer::evaluate_fn) may be customized before calling
+    /// [train](Trainer::train) by directly setting them on the returned [Trainer].
+    pub fn new(training_data: Vec<TrainingData>) -> Self {
+        return Trainer {
+            training_data,
+            evaluate_fn: basic_eval,
+            hidden_activation: sigmoid,
+            output_activation: sigmoid,
+        };
+    }
+
+    /// Train the given [gene_pool](Pool) over the course of `generations` generations.
+    /// The `training_data` provided when creating the [Trainer] will be used as part of this
+    /// process, as well as the current values of [evaluate_fn](Trainer::evaluate_fn),
+    /// [hidden_activation](Trainer::hidden_activation) and
+    /// [output_activation](Trainer::output_activation).
+    pub fn train(self, gene_pool: &mut Pool, generations: usize) {
+        let mut best_fitness = 0.0;
+
+        for generation in 0..generations {
+            info!("Evaluating generation {}", generation + 1);
+            let total_species = gene_pool.len();
+            for s in 0..total_species {
+                let species = &mut gene_pool[s];
+                let genomes_in_species = species.len();
+                for g in 0..genomes_in_species {
+                    let genome = &mut species[g];
+
+                    let mut fitness = 0.0;
+
+                    for td in &self.training_data {
+                        genome.evaluate(
+                            &td.inputs,
+                            Some(self.hidden_activation),
+                            Some(self.output_activation),
+                        );
+                        fitness += (self.evaluate_fn)(&genome.get_outputs(), &td.expected);
+                    }
+
+                    genome.update_fitness(fitness);
+
+                    if fitness > best_fitness {
+                        info!(
+                            "Species {} Genome {} increased best fitness to {}",
+                            s, g, best_fitness
+                        );
+                        best_fitness = fitness;
+                    }
+                }
+            }
+            gene_pool.new_generation();
+        }
+    }
+}


### PR DESCRIPTION
The `train_population` interface was a bit annoying, largely because ostensibly optional parameters (like activation functions) were required as `Option`s.